### PR TITLE
Add check script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.7.0]
+
+### Added
+- Add check script in order to identify missing keys as part of the CICD pipeline of an application using this package.
+
 ## [1.6.0]
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fjandin/config-man",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Config manager",
   "main": "index.js",
   "author": "René Bischoff <rene.bischoff@gmail.com> (https://github.com/fjandin)",

--- a/src/bin/check.ts
+++ b/src/bin/check.ts
@@ -1,0 +1,102 @@
+/* eslint-disable no-console */
+
+/**
+ * This script checks whether the defined configuration files contain all mandatory configuration items.
+ *
+ * Configuration items are expected to be present if ...
+ * 1) they have no `default` property in the config man schema file, and
+ * 2) they have no `"inJson": false` property in the config man schema file, and
+ * 3) they have no value in the configuration file.
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+import {exit} from 'process'
+
+import * as flatten from 'flat'
+import * as json5 from 'json5'
+
+enum ExitCode {
+    SUCCESS = 0,
+    UNEXPECTED_ERROR = 1,
+    MISSING_ITEMS = 2,
+}
+
+interface SchemaItem {
+    key: string
+    type: string
+    allowed?: any[]
+    default?: any
+    nullable?: boolean
+
+    // added to allow us to exclude items that explicitly come from elsewhere
+    inJson?: boolean
+}
+
+function main(schemaPath: string, schemaFilenames: string[]): string[] {
+    const schema = loadSchema(schemaPath)
+    const configFiles = schemaFilenames.map((it) => loadConfig(it))
+
+    return configFiles.reduce((missing, config, index) => {
+        const fileName = schemaFilenames[index]
+        const missingKeys = getConfigMissingKeys(config, schema)
+
+        if (missingKeys.length) {
+            missing.push(`'${fileName}' is missing configuration keys: ${missingKeys}`)
+        }
+
+        return missing
+    }, [] as string[])
+}
+
+try {
+    const args = process.argv.slice(2)
+
+    const schemaPath = args[0]
+    const schemaFilenames = args[1].split(',')
+    const missing = main(schemaPath, schemaFilenames)
+
+    if (missing.length) {
+        console.log(missing.join('\n'))
+        exit(ExitCode.MISSING_ITEMS)
+    } else {
+        exit(ExitCode.SUCCESS)
+    }
+} catch (err: any) {
+    console.error(
+        `Got an unexpected error trying to find missing configuration items: ${err.message}`,
+        err.stack,
+    )
+    exit(ExitCode.UNEXPECTED_ERROR)
+}
+
+function getConfigMissingKeys(config: Record<string, any>, schema: SchemaItem[]): string[] {
+    return schema
+        .filter(
+            // `default` is a reserved word, so we must rename
+            ({key, default: defaultValue}) =>
+                config[key] === undefined && defaultValue === undefined,
+        )
+        .map((it) => it.key)
+}
+
+function loadSchema(relativePath: string): SchemaItem[] {
+    const items: SchemaItem[] = loadJson(relativePath).schema
+    return items.filter(({inJson}) => inJson !== false)
+}
+
+function loadConfig(relativePath: string): Promise<Record<string, any>> {
+    const untyped = loadJson(relativePath)
+    return flatten(untyped)
+}
+
+function loadJson(relativePath: string): any {
+    const filePath = path.resolve(relativePath)
+
+    try {
+        const schemaRaw = fs.readFileSync(filePath, {encoding: 'utf-8'})
+        return json5.parse(schemaRaw)
+    } catch (error) {
+        throw new Error(`schema load error in '${relativePath}': ${(error as Error).message}`)
+    }
+}


### PR DESCRIPTION
- This script checks the configuration files and tries to identify any keys missing.
- It can be used as part of the CICD pipeline in order to ensure that the configuration files are complete

Usage example in package.json of the caller app:

```
"config:check": "node ./node_modules/@fjandin/config-man/bin/check.js ./src/config-man.json config.local.json5,config.staging.json5,config.production.json5",
```